### PR TITLE
Fix version of @passlock/sveltekit

### DIFF
--- a/packages/create-sveltekit/templates/daisy/package.json
+++ b/packages/create-sveltekit/templates/daisy/package.json
@@ -18,7 +18,7 @@
     "@lucia-auth/adapter-prisma": "^4.0.1",
     "@melt-ui/pp": "^0.3.2",
     "@melt-ui/svelte": "^0.83.0",
-    "@passlock/sveltekit": "0.9.7",
+    "@passlock/sveltekit": "0.9.27",
     "@sveltejs/adapter-auto": "^3.2.4",
     "@sveltejs/kit": "^2.5.27",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",


### PR DESCRIPTION
Seems like there was a typo in the version of @passlock/sveltekit, changed it from "0.9.7" to "0.9.27"